### PR TITLE
Variables de los colores agregadas

### DIFF
--- a/assets/colors.scss
+++ b/assets/colors.scss
@@ -1,0 +1,43 @@
+$blue900: #324D85;
+$blue800: #4069A5;
+$blue700: #477AB8;
+$blue600: #518BCA;
+$blue500: #5999D7;
+$blue400: #69A7DD;
+$blue300: #7EB7E2;
+$blue200: #9ECBEC;
+$blue100: #C2DFF3;
+$blue50:  #E6F2FA;
+
+$red900: #B4191D;
+$red800: #C32529;
+$red700: #D02C30;
+$red600: #E23636;
+$red500: #F14037;
+$red400: #EC5151;
+$red300: #E27173;
+$red200: #ED999A;
+$red100: #FECCD2;
+$red50:  #FEEBEE;
+
+$green900: #426032;
+$green800: #5F8242;
+$green700: #71964B;
+$green600: #83AA55;
+$green500: #92B95E;
+$green400: #A1C474;
+$green300: #B1CE8C;
+$green200: #C7DCAC;
+$green100: #DDEACC;
+$green50:  #F1F7EB;
+
+$gray900: #000000;
+$gray800: #262626;
+$gray700: #434343;
+$gray600: #555555;
+$gray500: #7B7B7B;
+$gray400: #9D9D9D;
+$gray300: #C4C4C4;
+$gray200: #D9D9D9;
+$gray100: #E9E9E9;
+$gray50:  #F5F5F5;


### PR DESCRIPTION
## Descripcion
Se agregan las variables sass para los colores que se definieron en figma

## Capturas de pantalla
![image](https://user-images.githubusercontent.com/40218829/114650569-170b7e00-9ca8-11eb-9be4-5f4309a4647e.png)


## Issue
[Link del issue](https://github.com/frontendcafe/cmyk-sunset/issues/44)
