### PR TITLE
Configuracion formateador

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "es6",
+        "baseUrl": ".",
+        "paths": {
+            "components/*": ["./components/*"],
+            "assets/*": ["./assets/*"]
+        }
+    },
+    "exclude": ["node_modules", ".next"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,6 +1799,12 @@
         }
       }
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -1996,7 +2002,7 @@
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
-       }
+      }
     },
     "sass": {
       "version": "1.32.8",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,19 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "sass": "^1.32.8"
+  },
+  "devDependencies": {
+    "prettier": "^2.2.1"
+  },
+  "prettier": {
+    "bracketSpacing": true,
+    "arrowParens": "avoid",
+    "useTabs": true,
+    "tabWidth": 2,
+    "endOfLine": "lf",
+    "jsxBracketSameLine": true,
+    "jsxSingleQuote": true,
+    "printWidth": 80,
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
## Descripcion
Instalacion de prettier como formateador

# Importancion de los componentes y assets
Con la adicion del archivo jsconfig.json los imports deben quedar mas limpios

<strong>eg.</strong>
Una page necesita importar el componente del Button

```jsx
import Button from "components/atoms/Button"

```

Normalmente el import quedaria de la siguiente manera
```js
import Button from "../components/atoms/Button"
```

## Issue
[Link del issue](https://github.com/frontendcafe/cmyk-sunset/projects/1#card-58767238)